### PR TITLE
Add `node_fw` git rev reporting

### DIFF
--- a/can/can.yml
+++ b/can/can.yml
@@ -46,15 +46,20 @@ messages:
 
 - dbwNode_Info:
     id: 0xD0
-    cycletime: 100
+    cycletime: 1000
+
+    template: dbwnodes
 
     signals:
       - Githash:
-           description: Githash of the currently-running firmware.
-           width: 32
+          description: Githash of the currently-running firmware.
+          width: 32
+      - GitDirty:
+          description: Repository was dirty at build time.
+          width: 1
       - EepromIdentity:
-           description: EEPROM identity.
-           width: 6
+          description: EEPROM identity.
+          width: 6
 
 - dbwNode_Accel_Data:
     id: 0x10

--- a/dbw/node_fw/lib/libgitrev/dirty.py
+++ b/dbw/node_fw/lib/libgitrev/dirty.py
@@ -1,0 +1,11 @@
+import subprocess
+
+def get_git_specifier():
+    dirt_stat = subprocess.run(['git diff-index --quiet HEAD --'], shell=True)
+    if dirt_stat.returncode != 0 and dirt_stat.returncode != 1:
+        print("Error describing git cleanliness.")
+        exit(-1)
+
+    print(f"-DBUILD_GIT_REV_DIRTY={dirt_stat.returncode}")
+
+get_git_specifier()

--- a/dbw/node_fw/lib/libgitrev/libgitrev.c
+++ b/dbw/node_fw/lib/libgitrev/libgitrev.c
@@ -1,0 +1,4 @@
+#include "libgitrev.h"
+
+uint32_t GITREV_BUILD_REV = BUILD_GIT_REV;
+bool GITREV_BUILD_DIRTY = BUILD_GIT_REV_DIRTY;

--- a/dbw/node_fw/lib/libgitrev/libgitrev.h
+++ b/dbw/node_fw/lib/libgitrev/libgitrev.h
@@ -1,0 +1,10 @@
+#ifndef LIB_GITREV_H
+#define LIB_GITREV_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+extern uint32_t GITREV_BUILD_REV;
+extern bool GITREV_BUILD_DIRTY;
+
+#endif

--- a/dbw/node_fw/lib/libgitrev/library.json
+++ b/dbw/node_fw/lib/libgitrev/library.json
@@ -1,0 +1,11 @@
+{
+  "name": "libgitrev",
+  "version": "1.0.0",
+  "description": "Connector for build-time git revision.",
+  "build": {
+    "flags": [
+      "!python3 rev.py",
+      "!python3 dirty.py"
+    ]
+  }
+}

--- a/dbw/node_fw/lib/libgitrev/rev.py
+++ b/dbw/node_fw/lib/libgitrev/rev.py
@@ -1,0 +1,12 @@
+import subprocess
+
+def get_git_specifier():
+    rev_stat = subprocess.run(['git rev-parse --short HEAD --'], shell=True, capture_output=True)
+    if rev_stat.returncode != 0:
+        print("Error describing git revision.")
+        exit(-1)
+
+    rev = rev_stat.stdout.rstrip()
+    print(f"-DBUILD_GIT_REV=0x{str(rev, 'utf-8').upper()}U")
+
+get_git_specifier()


### PR DESCRIPTION
Should be tested on a node before merge. This is implemented as a library with separate build flags so we don't have a global `-D` define changing all the time - that would cause everything to be rebuilt often.