### PR TITLE
Correctness improvements for CAN generation

### DIFF
--- a/can/SConscript
+++ b/can/SConscript
@@ -11,7 +11,7 @@ CAN_GENERATOR = env.File('gen_dbc.py')
 [gen_dbc] = env.Command(
         GENERATED_DBC,
         CAN_YML,
-        f'python {CAN_GENERATOR} --yml $SOURCE --dbc_out $TARGET')
+        f'{CAN_GENERATOR} --yml $SOURCE --dbc_out $TARGET')
 
 # generated C code
 gen_c_raw, gen_h_raw = env.Command(

--- a/can/gen_dbc.py
+++ b/can/gen_dbc.py
@@ -9,7 +9,7 @@ import os
 
 import strictyaml as sy
 
-VERSION = "0.003"
+VERSION = "0.0.4"
 
 def parse_signal(name: str, d: dict):
     choices = d.get("choices")
@@ -60,7 +60,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    print(f"Cooper IGVC CAN Network Generation v{VERSION}")
+    print(f"Cooper IGVC CAN Network Generation v{VERSION}\n")
 
     messages = []
 
@@ -100,7 +100,11 @@ if __name__ == "__main__":
         elif template_flag is None:
             pass
         else:
-            print('Error: value for "template" must be "yes"')
+            print(f'*** Error making {name}: value for "template" must be "yes"')
+            exit(-3)
+
+        if msg_width > 8:
+            print(f'*** Error making {name}: message length cannot exceed 8 bytes')
             exit(-3)
 
         messages.append(

--- a/can/gen_dbc.py
+++ b/can/gen_dbc.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 
 import cantools


### PR DESCRIPTION
Minor improvements:

- Make sure scons understands gen_dbc.py dependency (#74)
- Check that message length is not >8 bytes in gen_dbc
