### PR TITLE
Add pull_request and workflow_dispatch workflow triggers

### DIFF
--- a/.github/workflows/node_bl.yml
+++ b/.github/workflows/node_bl.yml
@@ -1,6 +1,6 @@
 name: Build node_bl
 
-on: [push]
+on: [pull_request, push, workflow_dispatch]
 
 jobs:
   pre_job:

--- a/.github/workflows/node_fw.yml
+++ b/.github/workflows/node_fw.yml
@@ -1,6 +1,6 @@
 name: Build node_fw
 
-on: [push]
+on: [pull_request, push, workflow_dispatch]
 
 jobs:
   pre_job:


### PR DESCRIPTION
Workflows only currently trigger on `push`, so PRs from forks do not trigger workflow runs and don't 
ask for approval to do so.

Add `pull_request` trigger so PRs also trigger runs and add `workflow_dispatch` so runs can be manually 
triggered too.
