### PR TITLE
Fix `libgitrev` submodule bug

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "dbw/node_fw/lib/ember"]
 	path = dbw/node_fw/lib/ember
 	url = ../ember.git
-[submodule "dbw/node_fw/lib/libgitrev"]
-	path = dbw/node_fw/lib/libgitrev
-	url = ../libgitrev.git

--- a/dbw/node_fw/lib/cuber-base/library.json
+++ b/dbw/node_fw/lib/cuber-base/library.json
@@ -1,5 +1,8 @@
 {
   "name": "cuber-base",
   "version": "1.0.0",
-  "description": "CUber base management task"
+  "description": "CUber base management task",
+  "dependencies": {
+    "libgitrev": "https://github.com/CooperUnion/libgitrev/archive/refs/tags/v1.0.1.zip"
+  }
 }


### PR DESCRIPTION
`libgitrev` as a submodule doesn't work because it ends up describing
the submodule rather than the parent repository.
