### PR TITLE
Bump `opencan` for tx mask fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,5 +64,5 @@ $(INSTALL_DEPENDENCIES): $(REQUIREMENTS_TXT)
 	$(PYTHON) -m $(PIP) install --upgrade pip wheel
 	$(PYTHON) -m $(PIP) install --upgrade $(LOCAL_PYTHON_LIBS)
 	$(PYTHON) -m $(PIP) install --requirement $(REQUIREMENTS_TXT)
-	cargo install --root build/cargo --locked --git https://github.com/opencan/opencan --rev 6875c435
+	cargo install --root build/cargo --locked --git https://github.com/opencan/opencan --rev 3206e406a
 	@touch $(INSTALL_DEPENDENCIES)


### PR DESCRIPTION
OpenCAN was not casting TX packing masks into the source variable type, leading to left-shift overflow warnings/errors with 64-bit-wide signals on targets with <64 bit wide ints (like the ESP32):

![image](https://user-images.githubusercontent.com/54985569/215303971-a4a43464-86a8-4b87-9d45-a8151a5c046c.png)
