### PR TITLE
Hotfix: re-disable EEPROM on dev

### DIFF
--- a/dbw/node_fw/src/module_list.inc
+++ b/dbw/node_fw/src/module_list.inc
@@ -29,7 +29,7 @@ ember_rate_funcs_S* ember_task_list[] = {
     &base_rf,
     &can_rf,
     // TODO: boards crash without EEPROM
-    &eeprom_rf,
+    // &eeprom_rf,
     &module_rf,
 };
 


### PR DESCRIPTION
`eeprom_rf` appears to have been re-enabled in `295716781` - disable it immediately to help more 1.1 boards be usable.

#83