### PR TITLE
updated fkirc/skip-duplicate-actions to v5.3.0

### DIFF
--- a/.github/workflows/node_bl.yml
+++ b/.github/workflows/node_bl.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v4
+        uses: fkirc/skip-duplicate-actions@v5.3.0
 
   build:
     needs: pre_job

--- a/.github/workflows/node_fw.yml
+++ b/.github/workflows/node_fw.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v4
+        uses: fkirc/skip-duplicate-actions@v5.3.0
 
   build:
     needs: pre_job


### PR DESCRIPTION
https://github.com/fkirc/skip-duplicate-actions/issues/292
updating "skip-duplicate-actions" in pre_job workflow
v4 of this workflow action uses deprecated commands, v5.2.0 fixed this. opted to just add latest though