### PR TITLE
DBW_RawVelocityCommand

### DIFF
--- a/can/can.yml
+++ b/can/can.yml
@@ -91,6 +91,7 @@ nodes:
     rx:
     - DBW_Active
     - DBW_ESTOP
+    - DBW_RawVelocityCommand
     messages:
     - Alarms:
         id: 0x22
@@ -172,6 +173,22 @@ nodes:
           - enable:
               description: Enable DBW active.
               width: 1
+
+    - RawVelocityCommand:
+        id: 0x667
+        cycletime: 100
+
+        signals:
+          - brakePercent:
+              description: Brake percentage.
+              # maximum: 100
+              unit: percent
+              width: 7
+          - throttlePercent:
+              description: Throttle percentage.
+              # maximum: 100
+              unit: percent
+              width: 7
 
     - VelocityCommand:
         id: 0x666

--- a/dbw/node_fw/mod/ctrl/ctrl.c
+++ b/dbw/node_fw/mod/ctrl/ctrl.c
@@ -5,6 +5,7 @@
 #include "common.h"
 #include "cuber_base.h"
 #include "ember_taskglue.h"
+#include "opencan_rx.h"
 #include "opencan_tx.h"
 
 // ######        DEFINES        ###### //
@@ -29,6 +30,8 @@ static void IRAM_ATTR encoder1_chan_b(void *arg);
 
 static volatile uint16_t pulse_cnt[2];
 static bool speed_alarm;
+static uint8_t brake_percent;
+static uint8_t throttle_percent;
 
 // ######    RATE FUNCTIONS     ###### //
 
@@ -86,6 +89,14 @@ static void ctrl_100Hz()
         base_set_state_estop(0 /* placeholder */);
     } else {
         speed_alarm = false;
+    }
+
+    if (CANRX_is_node_DBW_ok() && base_dbw_active()) {
+        brake_percent    = CANRX_get_DBW_brakePercent();
+        throttle_percent = CANRX_get_DBW_throttlePercent();
+    } else {
+        brake_percent    = 0;
+        throttle_percent = 0;
     }
 }
 
@@ -183,9 +194,8 @@ void CANTX_populate_CTRL_Alarms(struct CAN_Message_CTRL_Alarms * const m)
 
 void CANTX_populate_CTRL_VelocityCommand(struct CAN_Message_CTRL_VelocityCommand * const m)
 {
-    // TODO: populate with calculated values
-    m->CTRL_brakePercent    = 0;
-    m->CTRL_throttlePercent = 0;
+    m->CTRL_brakePercent    = brake_percent;
+    m->CTRL_throttlePercent = throttle_percent;
 }
 
 void CANTX_populateTemplate_EncoderData(struct CAN_TMessage_EncoderData * const m)

--- a/dbw/node_fw/mod/ctrl/ctrl.c
+++ b/dbw/node_fw/mod/ctrl/ctrl.c
@@ -10,8 +10,8 @@
 
 // ######        DEFINES        ###### //
 
-#define ENCODER0_CHAN_A 27
-#define ENCODER0_CHAN_B 26
+#define ENCODER0_CHAN_A 26
+#define ENCODER0_CHAN_B 27
 #define ENCODER1_CHAN_A 17
 #define ENCODER1_CHAN_B 0
 


### PR DESCRIPTION
We currently lack a way of manually setting brake and throttle percentages for testing. Since our old controller still runs as a Python script, the control node will exclusively use this message for velocity control for the time being.