### PR TITLE
Bump OpenCAN for library-related dependency update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,5 +64,5 @@ $(INSTALL_DEPENDENCIES): $(REQUIREMENTS_TXT)
 	$(PYTHON) -m $(PIP) install --upgrade pip wheel
 	$(PYTHON) -m $(PIP) install --upgrade $(LOCAL_PYTHON_LIBS)
 	$(PYTHON) -m $(PIP) install --requirement $(REQUIREMENTS_TXT)
-	cargo install --root build/cargo --locked --git https://github.com/opencan/opencan --rev 3206e406a
+	cargo install --root build/cargo --locked --git https://github.com/opencan/opencan --rev fad50a7
 	@touch $(INSTALL_DEPENDENCIES)


### PR DESCRIPTION
OpenCAN recently received an update with hash `fad50a7`, changes need to be made to the dev branch Makefile so the correct version is used during our builds from now on.