### PR TITLE
Pull in OpenCAN twos complement support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ $(ROS): $(INSTALL_DEPENDENCIES)
 	@$(MAKE) -C $(ROS)
 
 
-$(INSTALL_DEPENDENCIES): $(REQUIREMENTS_TXT)
+$(INSTALL_DEPENDENCIES): $(REQUIREMENTS_TXT) Makefile
 	$(PYTHON) -m $(PIP) install --upgrade pip wheel
 	$(PYTHON) -m $(PIP) install --upgrade $(LOCAL_PYTHON_LIBS)
 	$(PYTHON) -m $(PIP) install --requirement $(REQUIREMENTS_TXT)

--- a/Makefile
+++ b/Makefile
@@ -63,5 +63,5 @@ $(INSTALL_DEPENDENCIES): $(REQUIREMENTS_TXT) Makefile
 	$(PYTHON) -m $(PIP) install --upgrade pip wheel
 	$(PYTHON) -m $(PIP) install --upgrade $(LOCAL_PYTHON_LIBS)
 	$(PYTHON) -m $(PIP) install --requirement $(REQUIREMENTS_TXT)
-	cargo install --root build/cargo --locked --git https://github.com/opencan/opencan --rev f90d5c42
+	cargo install --root build/cargo --locked --git https://github.com/opencan/opencan --rev 48944e0a
 	@touch $(INSTALL_DEPENDENCIES)

--- a/can/can.yml
+++ b/can/can.yml
@@ -274,7 +274,7 @@ nodes:
               # minimum: -0.610865238
               # maximum: 0.610865238
               scale: 0.000000001
-              # is_signed: true
+              twos_complement: true
               width: 32
 
           - encoderTimeoutSet:

--- a/ros/Makefile
+++ b/ros/Makefile
@@ -37,7 +37,7 @@ build-clean: pydeps
 
 
 .PHONY: pydeps
-pydeps:
+pydeps: Makefile
 	@rm -rf $(CAND_DST) $(CANTOOLS_DST) $(IGVCUTILS_DST)
 	@echo $(CAND_DST)      | xargs -n 1 cp -r $(CAND_SRC)
 	@echo $(CANTOOLS_DST)  | xargs -n 1 cp -r $(CANTOOLS_SRC)


### PR DESCRIPTION
This removes the STEER_angle hack and introduces proper twos complement
support.

- Have Makefile targets depend on the Makefile
- Bump opencan for twos complement support
- Set STEER_angle as twos complement in can.yml
