### PR TITLE
Rename STEER_SteeringCmd to DBW_SteeringCommand

### DIFF
--- a/can/can.yml
+++ b/can/can.yml
@@ -190,6 +190,19 @@ nodes:
               unit: percent
               width: 7
 
+    - SteeringCommand:
+        id: 0x21
+        cycletime: 100
+
+        signals:
+          - steeringAngleCmd:
+              description: Absolute steering angle in radians.
+              # minimum: -0.471238898
+              # maximum: 0.471238898
+              scale: 0.000000001
+              # is_signed: true
+              width: 32
+
     - VelocityCommand:
         id: 0x666
         cycletime: 100
@@ -284,19 +297,6 @@ nodes:
           - oDriveConnected:
               description: Is the ODrive connected?
               width: 1
-
-    - SteeringCmd:
-        id: 0x21
-        cycletime: 100
-
-        signals:
-          - angleCmd:
-              description: Absolute steering angle in radians.
-              # minimum: -0.471238898
-              # maximum: 0.471238898
-              scale: 0.000000001
-              # is_signed: true
-              width: 32
 
 - TEST:
     rx: "*"

--- a/dbw/py-steering/steer.py
+++ b/dbw/py-steering/steer.py
@@ -148,17 +148,17 @@ class Steer(threading.Thread):
                     time.sleep(self.MESSAGE_RATE_S)
                     continue
 
-                rec = self._bus.get('STEER_SteeringCmd')
+                rec = self._bus.get('DBW_SteeringCommand')
 
                 if rec:
                     unix_time_ns, data = rec
 
                     if time.time_ns() - unix_time_ns >= self.CMD_TIMEOUT_NS:
-                        self._base.set_state_estop('TIEMOUT', 'command timeout')
+                        self._base.set_state_estop('TIMEOUT', 'command timeout')
                         time.sleep(self.MESSAGE_RATE_S)
                         continue
 
-                    self._des_angle = math.degrees(data['STEER_angleCmd'])
+                    self._des_angle = math.degrees(data['DBW_steeringAngleCmd'])
 
                     self._odrive_en(True)
                     self._axis.controller.input_vel = self._pid.step(

--- a/ros/docker/techbus/src/techbus.py
+++ b/ros/docker/techbus/src/techbus.py
@@ -11,7 +11,7 @@ from std_msgs.msg import UInt16MultiArray, String
 # CAN Messages
 EncoderCAN = 'CTRL_EncoderData'
 VelocityCAN = 'DBW_VelocityCommand'
-SteerCAN = 'STEER_SteeringCmd'
+SteerCAN = 'DBW_SteeringCommand'
 
 # ROS Topics
 PPTwist = '/cmd_vel'
@@ -20,7 +20,7 @@ EncoderTicks = '/encoder_ticks'
 # Creates subscriber object that listens for the /cmd_vel topic
 # Whenever the subscriber receives data, the callback function runs
 # The callback function extracts a usable linear velocity and steering angle from the data
-# It sends these commands over the DBW_VelocityCmd and STEER_SteeringCmd CAN messages
+# It sends these commands over the DBW_VelocityCmd and DBW_SteeringCommand CAN messages
 class ROStouCAN:
     def __init__(self):
         self.bus = cand.client.Bus(redis_host='redis')
@@ -36,7 +36,7 @@ class ROStouCAN:
             'DBW_linearVelocity': msg.linear.x
         })
         self.bus.send(SteerCAN, {
-            'STEER_angleCmd': angle
+            'DBW_steeringAngleCmd': angle
         })
 
 # Establishes publisher for the /encoder_ticks topic

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -13,8 +13,8 @@ class Test:
     def run(self, percent, duration):
         self._bus.send('DBW_Active', {'DBW_active': 1})
         self._bus.send(
-            'STEER_SteeringCmd',
-            {'STEER_angleCmd': 0.0},
+            'DBW_SteeringCommand',
+            {'DBW_steeringAngleCmd': 0.0},
         )
 
         time_start = time.time()


### PR DESCRIPTION
- Rename STEER_SteeringCmd to DBW_SteeringCommand
- Use DBW_SteeringCommand in techbus and test_steering.py

