### PR TITLE
Change temperature message width from 7 bits to 8 bits

### DIFF
--- a/can/can.yml
+++ b/can/can.yml
@@ -29,7 +29,7 @@ message_templates:
           #min: -30
           #max: 50
           description: Core temperature in Celsius
-          width: 7
+          width: 8
           offset: 30
       - counter:
           description: Counter for fun.

--- a/can/can.yml
+++ b/can/can.yml
@@ -26,11 +26,9 @@ message_templates:
             - ACTIVE
             - ESTOP
       - temperature:
-          #min: -30
-          #max: 50
           description: Core temperature in Celsius
-          width: 8
-          offset: 30
+          width: 7
+          offset: 31
       - counter:
           description: Counter for fun.
           width: 8

--- a/dbw/node_fw/lib/cuber-base/cuber_base.c
+++ b/dbw/node_fw/lib/cuber-base/cuber_base.c
@@ -239,7 +239,7 @@ void CANTX_populateTemplate_NodeStatus(struct CAN_TMessage_DBWNodeStatus * const
     m->temperature = tsens_value;
     printf("%f\n", tsens_value);
 #else
-    m->temperature = 100.0;
+    m->temperature = -31.0;
 #endif
 
     static typeof(m->counter) counter;


### PR DESCRIPTION
Fixed bug where error temperature of 100 degrees C was not within the signal width bounds. Changed temperature message width from 7 to 8 bits to account for 100 + offset of 30.