### PR TITLE
Specify libdeps_dir in node_fw platformio.ini

### DIFF
--- a/dbw/node_fw/platformio.ini
+++ b/dbw/node_fw/platformio.ini
@@ -11,6 +11,7 @@
 [platformio]
 boards_dir = ccmn_defs/pio-boards
 build_dir = ../../build/dbw/node_fw
+libdeps_dir = ../../build/dbw/node_fw/libdeps
 
 [env]
 platform = espressif32@6.1.0


### PR DESCRIPTION
Sometimes, platformio will make a libdeps folder. Make sure it's in
build/.
