### PR TITLE
Use scons to manage opencan-cli dependency

### DIFF
--- a/.github/workflows/node_fw.yml
+++ b/.github/workflows/node_fw.yml
@@ -33,11 +33,26 @@ jobs:
           path: dbw/node_fw/.pio
           key: pio_cache
 
-      - name: Run setup
-        run: ./setup.sh
+#      - name: Run setup
+#        run: ./setup.sh
+
+      - name: Run make dependencies
+        run: make dependencies
+
+      - name: Configure Rust
+        run: |
+          #          ls -lR $HOME/.cargo
+          #          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          echo $CARGO_HOME
+          echo $PATH
+          #rustup default stable
 
       - name: Build CAN network
-        run: . .venv/bin/activate && scons dbc
+        run: |
+          echo $PATH
+          echo $CARGO_HOME
+          rustup default stable
+          . .venv/bin/activate && scons dbc
 
       - name: Build firmware
         run: . .venv/bin/activate && make dbw/node_fw

--- a/Makefile
+++ b/Makefile
@@ -63,5 +63,4 @@ $(INSTALL_DEPENDENCIES): $(REQUIREMENTS_TXT) Makefile
 	$(PYTHON) -m $(PIP) install --upgrade pip wheel
 	$(PYTHON) -m $(PIP) install --upgrade $(LOCAL_PYTHON_LIBS)
 	$(PYTHON) -m $(PIP) install --requirement $(REQUIREMENTS_TXT)
-	cargo install --root build/cargo --locked --git https://github.com/opencan/opencan --rev b014266
 	@touch $(INSTALL_DEPENDENCIES)

--- a/can/SConscript
+++ b/can/SConscript
@@ -1,24 +1,36 @@
 Import('env')
 
-OPENCAN_BIN     = env.File('$REPO_ROOT/build/cargo/bin/opencan-cli')
+OPENCAN_VERSION     = 'b014266'
+OPENCAN_CLI         = env.File('$REPO_ROOT/build/cargo/bin/opencan-cli')
+
+# Install opencan ----------------------------------------
+[opencan_cli_builder] = env.Command(
+    OPENCAN_CLI,
+    [],
+    f'cargo install --root $REPO_ROOT/build/cargo --locked --git https://github.com/opencan/opencan --rev {OPENCAN_VERSION}'
+)
+# --------------------------------------------------------
+
+# Make DBC -----------------------------------------------
 GENERATED_DBC   = env.File('igvc_can.dbc')
 CAN_YML         = env.File('can.yml')
-
 DBC_EMITTER     = env.File('create-dbc.py')
 
 # Make emitter script
-[dbc_emitter] = env.Command(
+env.Command(
     DBC_EMITTER,
-    CAN_YML,
-    f'{OPENCAN_BIN} compose $SOURCE --dump-python > $TARGET'
+    [OPENCAN_CLI, CAN_YML],
+    f'{OPENCAN_CLI} compose {CAN_YML} --dump-python > $TARGET'
 )
 
 # Make DBC by running emitter script
-[dbc] = env.Command(
+[dbc_builder] = env.Command(
     GENERATED_DBC,
     DBC_EMITTER,
     [f'python3 {DBC_EMITTER.path}',
      Move("$TARGET", "opencan.dbc")]
 )
+# --------------------------------------------------------
 
-env.Alias('dbc', dbc)
+env.Alias('dbc', dbc_builder)
+env.Alias('opencan_cli', opencan_cli_builder)

--- a/dbw/node_fw/opencan-pio.py
+++ b/dbw/node_fw/opencan-pio.py
@@ -9,10 +9,14 @@ gen_dir     = build_dir.Dir(f"../opencan_generated/{node}")
 # These Execute calls call opencan-cli every time.
 # They could be replaced with a proper Command, but it was tricky getting
 # PlatformIO to reliably execute them. You could ask them on GitHub or similar.
+if 0 != env.Execute(f'scons -D opencan_cli'):
+    print("Error making sure opencan-cli is installed; stopping build.")
+    exit(-1)
+
 env.Execute(Mkdir(gen_dir.path))
 
 if 0 != env.Execute(f'{opencan} codegen {yml} {gen_dir} {node}'):
-    print("OpenCAN error, stopping build.")
+    print("OpenCAN error; stopping build.")
     exit(-1)
 
 # Add gen_dir to the CPPPATH


### PR DESCRIPTION
This is an insane quality of life improvement. No more make dependencies for opencan. From the repo root, you can run `scons opencan_cli` to manually install it. `scons dbc` will install it if needed. 

`dbw/node_fw/opencan-pio.py` runs `scons -D opencan_cli` to make sure that opencan is installed before it tries to use it for codegen.

The version (githash) is specified in `can/SConscript`.