### PR TITLE
Add `mdbook` docs

### DIFF
--- a/.github/workflows/mdbook-deploy.yml
+++ b/.github/workflows/mdbook-deploy.yml
@@ -1,0 +1,35 @@
+---
+
+name: mdbook-deploy
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install latest version of `mdbook`
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: latest
+
+      - name: Build docs
+        run: mdbook build
+
+      - name: Deploy docs
+        uses: s0/git-publish-subdir-action@develop
+        env:
+          REPO: self
+          BRANCH: build/docs
+          FOLDER: build/docs
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SKIP_EMPTY_COMMITS: true
+          MESSAGE: '{long-sha}'

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -1,0 +1,23 @@
+---
+
+name: mdbook
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install latest version of `mdbook`
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: latest
+
+      - name: Build docs
+        run: mdbook build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,12 @@ repos:
       - id: end-of-file-fixer
       - id: requirements-txt-fixer
       - id: trailing-whitespace
+
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.17
+    hooks:
+      - id: mdformat
+        args: [--wrap, '72']
+        exclude: LICENSE\.md
+        additional_dependencies:
+          - mdformat-gfm

--- a/README.md
+++ b/README.md
@@ -11,15 +11,14 @@ selfdrive/
           tools/  - Miscellaneous tools and resources
 ```
 
-------------------------------------------------------------------------------
+______________________________________________________________________
 
 ## Copyright & Licensing
 
-Copyright (C) 2021-2022  Autonomy Lab
+Copyright (C) 2021-2022 Autonomy Lab
 
-Copyright (C) 2021-2022  Cooper IGVC
+Copyright (C) 2021-2022 Cooper IGVC
 
 Distributed under the [GPLv3] only.
 
-
-[GPLv3]: LICENSE.md
+[gplv3]: LICENSE.md

--- a/book.toml
+++ b/book.toml
@@ -1,0 +1,13 @@
+[book]
+title       = 'Autonomy Lab Documentation'
+description = 'The official documentation of Autonomy Lab at The Cooper Union for the Advancement of Science and Art'
+language    = 'en'
+src         = 'docs'
+
+[build]
+build-dir = 'build/docs'
+
+[output.html]
+mathjax-support    = true
+no-section-label   = true
+git-repository-url = 'https://github.com/CooperUnion/selfdrive'

--- a/dbw/node_fw/README.md
+++ b/dbw/node_fw/README.md
@@ -1,10 +1,10 @@
 # Node Firmware
 
-
 ## Docker Build Container
 
-In an effort to create a consistent build environment, we've created a docker
-container for building firmware.  To get up and running simply run:
+In an effort to create a consistent build environment, we've created a
+docker container for building firmware. To get up and running simply
+run:
 
 ```bash
 docker run \

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Overview
+
+Hello and welcome to the official documentation of Autonomy Lab at The
+Cooper Union for the Advancement of Science and Art!
+
+## License
+
+Autonomy Lab's documentation is distributed under the [CC BY-NC-SA 4.0].
+
+[cc by-nc-sa 4.0]: https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,7 @@
+# Summary
+
+[Overview](README.md)
+
+______________________________________________________________________
+
+[Contributors](contributors.md)

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -1,0 +1,6 @@
+# Contributors
+
+Here is a list of the contributors who have helped in writing our
+documentation, huge shout-out to them!
+
+- Jacob Koziej (EE '25)

--- a/ros/README.md
+++ b/ros/README.md
@@ -1,34 +1,53 @@
 # ROS Environment
+
 ## Prerequisite
-Refer to [documentation](https://confluence.cooperigvc.org/display/TECH/Initial+Environment+Setup) on how to install each component
+
+Refer to
+[documentation](https://confluence.cooperigvc.org/display/TECH/Initial+Environment+Setup)
+on how to install each component
+
 - Docker Engine
 - Docker-Compose
 - NVIDIA-Docker
 
----
+______________________________________________________________________
+
 ## Usage
+
 ### Starting services
+
 1. Allow docker to xhost
+
 ```bash
 xhost +si:localuser:root
 ```
-2. Spin up the containers ***[YOU MUST ALWAYS SPIN UP MASTER]***
+
+2. Spin up the containers ***\[YOU MUST ALWAYS SPIN UP MASTER\]***
+
 ```bash
 docker-compose up -d master <services>
 ```
-Where <services> are the containers you want to spin up from the docker-compose.yml file.
 
-For example, if you want to spin up the zed container, run the following command:
+Where <services> are the containers you want to spin up from the
+docker-compose.yml file.
+
+For example, if you want to spin up the zed container, run the following
+command:
+
 ```bash
 docker-compose up -d master zed
 ```
+
 ### Stopping services
+
 ```
 docker-compose down
 ```
 
----
+______________________________________________________________________
+
 ## Available Services
+
 - master
 - gazebo
 - rplidar

--- a/ros/docker/gazebo/igvc_self_drive_sim/README.md
+++ b/ros/docker/gazebo/igvc_self_drive_sim/README.md
@@ -1,9 +1,18 @@
 # IGVC Self-Drive Gazebo Simulator
-This repository provides a Gazebo model of a Polaris GEM, as well as worlds and models to simulate the tasks of the competition.
 
-**If using ROS Noetic**, you need to clone the [hector_models](https://github.com/tu-darmstadt-ros-pkg/hector_models.git) and [hector_gazebo](https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git) repositories into the same workspace as this repositoriy.
+This repository provides a Gazebo model of a Polaris GEM, as well as
+worlds and models to simulate the tasks of the competition.
 
-After cloning into a ROS workspace along with `hector_gazebo` and `hector_models` if necessary, run the following the command from the root of the workspace to install additional ROS package dependencies to make everything work correctly:
+**If using ROS Noetic**, you need to clone the
+[hector_models](https://github.com/tu-darmstadt-ros-pkg/hector_models.git)
+and
+[hector_gazebo](https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git)
+repositories into the same workspace as this repositoriy.
+
+After cloning into a ROS workspace along with `hector_gazebo` and
+`hector_models` if necessary, run the following the command from the
+root of the workspace to install additional ROS package dependencies to
+make everything work correctly:
 
 `rosdep install --from-paths src --ignore-src -r`
 
@@ -11,82 +20,127 @@ After cloning into a ROS workspace along with `hector_gazebo` and `hector_models
 
 `roslaunch gazebo_ros empty_world.launch`
 
-To load a custom Gazebo world file, pass its file path to the `world_name` argument:
+To load a custom Gazebo world file, pass its file path to the
+`world_name` argument:
 
 `roslaunch gazebo_ros empty_world.launch world_name:=<complete path to world file here\>`
 
-Spawn the GEM model in Gazebo with `spawn_gem.launch` in the `igvc_self_drive_gazebo` package:
+Spawn the GEM model in Gazebo with `spawn_gem.launch` in the
+`igvc_self_drive_gazebo` package:
 
 `roslaunch igvc_self_drive_gazebo spawn_gem.launch`
 
-The `spawn_gem.launch` file has arguments that allow the user to control some aspects of the spawned GEM:
+The `spawn_gem.launch` file has arguments that allow the user to control
+some aspects of the spawned GEM:
 
-* `start_x`, `start_y`, `start_z`: The `x`, `y`, `z` position of the vehicle in Gazebo
+- `start_x`, `start_y`, `start_z`: The `x`, `y`, `z` position of the
+  vehicle in Gazebo
 
-* `start_yaw`: The direction the vehicle faces relative to the Gazebo world frame
+- `start_yaw`: The direction the vehicle faces relative to the Gazebo
+  world frame
 
-* `twist_mode`: If true, the GEM subscribes to a `geometry_msgs/Twist` topic to move around the world. If false, it subscribes to individual actuator command topics. See the discussion of these modes below.
+- `twist_mode`: If true, the GEM subscribes to a `geometry_msgs/Twist`
+  topic to move around the world. If false, it subscribes to individual
+  actuator command topics. See the discussion of these modes below.
 
-* `pub_tf`: If true, a ground truth TF transform from `world` frame to `base_footprint` frame is published
+- `pub_tf`: If true, a ground truth TF transform from `world` frame to
+  `base_footprint` frame is published
 
 ### Simulating IGVC Tasks
 
-The `self_drive_tasks.world` file in the `igvc_self_drive_gazebo` package simulates the specific tasks as described in the official rules document, which can be found [[here](http://www.igvc.org/2018selfdriverules.pdf)].
+The `self_drive_tasks.world` file in the `igvc_self_drive_gazebo`
+package simulates the specific tasks as described in the official rules
+document, which can be found
+\[[here](http://www.igvc.org/2018selfdriverules.pdf)\].
 
-To load the world and spawn the vehicle at the starting point for a particular task, run the corresponding launch file in the `igvc_self_drive_gazebo` package. For example, to run task F3, the right turn test where the vehicle has to stop at the intersection:
+To load the world and spawn the vehicle at the starting point for a
+particular task, run the corresponding launch file in the
+`igvc_self_drive_gazebo` package. For example, to run task F3, the right
+turn test where the vehicle has to stop at the intersection:
 
 `roslaunch igvc_self_drive_gazebo f3_gazebo.launch`
 
-At the moment, the F9 task is not implemented in the `self_drive_tasks.world` Gazebo world, even though the launch file for it exists.
+At the moment, the F9 task is not implemented in the
+`self_drive_tasks.world` Gazebo world, even though the launch file for
+it exists.
 
 ### Sensor Data Topics
+
 The following topics are published by Gazebo:
 
-* `/fix`: GPS position given in latitude and longitude in the form of a `sensor_msgs/NavSatFix` message
+- `/fix`: GPS position given in latitude and longitude in the form of a
+  `sensor_msgs/NavSatFix` message
 
-* `/camera_front/image_raw/*`: Standard group of image topics from `image_proc`
+- `/camera_front/image_raw/*`: Standard group of image topics from
+  `image_proc`
 
-* `/scan`: LIDAR scan data in the form of a `sensor_msgs/LaserScan` message
+- `/scan`: LIDAR scan data in the form of a `sensor_msgs/LaserScan`
+  message
 
-* `/twist`: The current measurement of the vehicle's speed and yaw rate in a `geometry_msgs/TwistStamped` message. The `linear.x` field contains the speed in m/s and `angular.z` contains the yaw rate in rad/s
+- `/twist`: The current measurement of the vehicle's speed and yaw rate
+  in a `geometry_msgs/TwistStamped` message. The `linear.x` field
+  contains the speed in m/s and `angular.z` contains the yaw rate in
+  rad/s
 
-* `/gear_state`: The current gear of the vehicle in a `std_msgs/UInt8` message:
-    * 0 = Forward
-    * 1 = Reverse
+- `/gear_state`: The current gear of the vehicle in a `std_msgs/UInt8`
+  message:
 
-* `/sonar/*`: Group of 10 sonar sensor range measurement topics in separate `sensor_msgs/Range` messages. There are three sensors on the front of the vehicle, three on the rear, and two on either side.
+  - 0 = Forward
+  - 1 = Reverse
+
+- `/sonar/*`: Group of 10 sonar sensor range measurement topics in
+  separate `sensor_msgs/Range` messages. There are three sensors on the
+  front of the vehicle, three on the rear, and two on either side.
 
 ### Controlling the Simulated Vehicle
+
 The Gazebo GEM model can be controlled in two different modes:
 
-* **Twist Mode:** Send a `geometry_msgs/Twist` message on the `/cmd_vel` topic with desired speed and yaw rate, and let the simulation generate the appropriate actuator commands.
+- **Twist Mode:** Send a `geometry_msgs/Twist` message on the `/cmd_vel`
+  topic with desired speed and yaw rate, and let the simulation generate
+  the appropriate actuator commands.
 
-* **Actuator Mode:** Send throttle, brake, steering, and gear actuator commands directly to the simulator.
+- **Actuator Mode:** Send throttle, brake, steering, and gear actuator
+  commands directly to the simulator.
 
 #### Twist Mode (default)
-The control mode is specified by setting the `twist_mode` argument to the `spawn_gem.launch` file to true or false. This argument defaults to true, so if you don't have to change anything to use Twist Mode.
 
-The `linear.x` field of the user's `geometry_msgs/Twist` message should contain the desired speed in m/s, and the `angular.z` field should contain the desired yaw rate in rad/s.
+The control mode is specified by setting the `twist_mode` argument to
+the `spawn_gem.launch` file to true or false. This argument defaults to
+true, so if you don't have to change anything to use Twist Mode.
+
+The `linear.x` field of the user's `geometry_msgs/Twist` message should
+contain the desired speed in m/s, and the `angular.z` field should
+contain the desired yaw rate in rad/s.
 
 #### Actuator Mode
-By setting the `twist_mode` argument to false, the Gazebo plugin instead subscribes to four separate actuator command topics so the user can control them directly:
 
-* `/throttle_cmd`: `std_msgs/Float64` topic containing commanded throttle percentage (0 to 1)
+By setting the `twist_mode` argument to false, the Gazebo plugin instead
+subscribes to four separate actuator command topics so the user can
+control them directly:
 
-* `/brake_cmd`: `std_msgs/Float64` topic containing commanded brake torque in Newton-meters (0 to 1000)
+- `/throttle_cmd`: `std_msgs/Float64` topic containing commanded
+  throttle percentage (0 to 1)
 
-* `/steering_cmd`: `std_msgs/Float64` topic containing commanded steering wheel angle in radians (-9.5 to +9.5)
+- `/brake_cmd`: `std_msgs/Float64` topic containing commanded brake
+  torque in Newton-meters (0 to 1000)
 
-* `/gear_cmd`: `std_msgs/UInt8` topic containing commanded gear, as controlled by the switch on the dashboard of the real vehicle:
-    * 0 = Forward
-    * 1 = Reverse
+- `/steering_cmd`: `std_msgs/Float64` topic containing commanded
+  steering wheel angle in radians (-9.5 to +9.5)
+
+- `/gear_cmd`: `std_msgs/UInt8` topic containing commanded gear, as
+  controlled by the switch on the dashboard of the real vehicle:
+
+  - 0 = Forward
+  - 1 = Reverse
 
 ### Some Useful Kinematics Parameters
 
-* Gear ratio between steering wheel and equivalent bicycle steer angle = 17 : 1
+- Gear ratio between steering wheel and equivalent bicycle steer angle =
+  17 : 1
 
-* Wheelbase = 2.4 meters
+- Wheelbase = 2.4 meters
 
-* Track width = 1.2 meters
+- Track width = 1.2 meters
 
-* Wheel radius = 0.36 meters
+- Wheel radius = 0.36 meters

--- a/sim/README.md
+++ b/sim/README.md
@@ -1,12 +1,14 @@
 # Simulation
 
 ### CARLA 0.9.12 simulator install
-https://carla.readthedocs.io/en/latest/start_quickstart/
-follow the Package installation section.
+
+https://carla.readthedocs.io/en/latest/start_quickstart/ follow the
+Package installation section.
 
 don't install using whl or egg cause they're not up-to-date or some shit
 
 - install via curl
+
 ```bash
 # this takes super long so go eat lunch or watch a movie
 curl -L https://carla-releases.s3.eu-west-3.amazonaws.com/Linux/CARLA_0.9.12.tar.gz > carla-0.9.12.tar.gz

--- a/tools/manuals/README.md
+++ b/tools/manuals/README.md
@@ -1,3 +1,4 @@
 # Notes
 
-- The GEM service manual says -2019 and our GEM is a 2020 model, but the dealer says it's the same manual.
+- The GEM service manual says -2019 and our GEM is a 2020 model, but the
+  dealer says it's the same manual.


### PR DESCRIPTION
The following adds [`mdbook`] docs to the repo, a pre-commit hook to enable [`mdformat`] to normalize markdown files, and a GitHub action to automatically deploy docs once they're merged into `dev` to the `build/docs` branch.

[`mdbook`]: https://rust-lang.github.io/mdBook/
[`mdformat`]: https://github.com/executablebooks/mdformat