### PR TITLE
NumPy Zlib fix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,11 @@
             python
             rust
           ];
+
+          shellHook = ''
+            export LD_LIBRARY_PATH="''${LD_LIBRARY_PATH:-}"
+            export LD_LIBRARY_PATH="${pkgs.zlib}/lib:''$LD_LIBRARY_PATH"
+          '';
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
             pkgs.act
             pkgs.mdbook
             pkgs.nixpkgs-fmt
+            pkgs.zlib
             python
             rust
           ];


### PR DESCRIPTION
The following resolves an issue with `numpy` being unable to find `libz.so.1`.