### PR TITLE
Set SCons default working directory to the repo root

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -56,5 +56,6 @@ if [ ! -f "$DIRENV_INSTALLED_CRATES" ]; then
 	invoke deps.cargo.install
 fi
 
+export SCONSFLAGS="${SCONSFLAGS:+$SCONSFLAGS }-C $(pwd)"
 
 pre-commit install --allow-missing-config

--- a/.envrc
+++ b/.envrc
@@ -8,6 +8,7 @@ watch_file './rust-toolchain.toml'
 watch_file './site_scons/env.py'
 
 eval $(./site_scons/env.py --export)
+export SCONSFLAGS="${SCONSFLAGS:-} --directory=$(expand_path .)"
 
 
 COLOR_MAGENTA="\033[1;35m"
@@ -55,7 +56,5 @@ if [ ! -f "$DIRENV_INSTALLED_CRATES" ]; then
 
 	invoke deps.cargo.install
 fi
-
-export SCONSFLAGS="${SCONSFLAGS:+$SCONSFLAGS }-C $(pwd)"
 
 pre-commit install --allow-missing-config

--- a/.envrc
+++ b/.envrc
@@ -8,6 +8,7 @@ watch_file './rust-toolchain.toml'
 watch_file './site_scons/env.py'
 
 eval $(./site_scons/env.py --export)
+
 export SCONSFLAGS="${SCONSFLAGS:-} --directory=$(expand_path .)"
 
 
@@ -56,5 +57,6 @@ if [ ! -f "$DIRENV_INSTALLED_CRATES" ]; then
 
 	invoke deps.cargo.install
 fi
+
 
 pre-commit install --allow-missing-config


### PR DESCRIPTION
added --directory flag to SCONSFLAGS to allow running scons from any subdirectory in the repo